### PR TITLE
Combine `budget` data into `categories`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.1.0] - 2020-12-03
 ### Added
-- Add a changelog
+- Add a "note" field to `transactions`
 
 ## [1.0.0] - 2020-07-12
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Remove `budget` data as a separate list
+
+### Changed
+- Merge `budget` data fields into `categories` data
 
 ## [1.1.0] - 2020-12-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,5 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Specify structure of `categories` data
 - Specify structure of `transactions` data
 
-[Unreleased]: https://github.com/forevermatt/budget-data/compare/1.0.0...develop
+[Unreleased]: https://github.com/forevermatt/budget-data/compare/1.1.0...develop
+[1.1.0]: https://github.com/forevermatt/budget-data/releases/tag/1.1.0
 [1.0.0]: https://github.com/forevermatt/budget-data/releases/tag/1.0.0

--- a/README.md
+++ b/README.md
@@ -15,26 +15,17 @@ The list of a user's financial accounts:
       *...*
     ]
 
-### Budget
-
-The amount a user has currently budgeted (per month) for each category:
-
-    {
-      "*category uuid*": {
-        "budgeted": *allotted amount for this month, in cents*,
-        "remaining": *amount remaining in this category*,
-        "refilled": "*YYYY-MM*"
-      },
-      *...*
-    }
-
 ### Categories
 
-A user's list of budget categories:
+A user's list of budget categories, including the amount currently budgeted (per
+month) for each category:
 
     [
       {
+        "budgeted": *allotted amount per month for this category, in cents*,
         "name": "*category name*",
+        "remaining": *amount remaining in this category*,
+        "refilled": "*YYYY-MM*"
         "uuid": "*category uuid*"
       },
       *...*


### PR DESCRIPTION
### Removed
- Remove `budget` data as a separate list

### Changed
- Merge `budget` data fields into `categories` data

### Fixed
- Update changelog with info about most recent previous version (1.1.0)