### PR TITLE
Release 2.0.0 - Merge `budget` data into `categories`, rename `uuid` to `id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0] - 2025-08-14
+## [2.0.0] - 2025-08-15
 ### Removed
 - Remove `budget` data as a separate list
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.1.0] - 2020-12-03
 ### Added
-- Add a changelog
+- Add a "note" field to `transactions`
 
 ## [1.0.0] - 2020-07-12
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Merge `budget` data fields into `categories` data
+- Rename `uuid` fields to `id` (or optionally `_id`)
 
 ## [1.1.0] - 2020-12-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Remove `budget` data as a separate list
+
+### Changed
+- Merge `budget` data fields into `categories` data
 
 ## [1.1.0] - 2020-12-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,5 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Specify structure of `categories` data
 - Specify structure of `transactions` data
 
-[Unreleased]: https://github.com/forevermatt/budget-data/compare/1.0.0...develop
+[Unreleased]: https://github.com/forevermatt/budget-data/compare/1.1.0...develop
+[1.1.0]: https://github.com/forevermatt/budget-data/releases/tag/1.1.0
 [1.0.0]: https://github.com/forevermatt/budget-data/releases/tag/1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.0.0] - 2025-08-14
 ### Removed
 - Remove `budget` data as a separate list
 
@@ -23,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Specify structure of `categories` data
 - Specify structure of `transactions` data
 
-[Unreleased]: https://github.com/forevermatt/budget-data/compare/1.1.0...develop
+[Unreleased]: https://github.com/forevermatt/budget-data/compare/2.0.0...develop
+[2.0.0]: https://github.com/forevermatt/budget-data/releases/tag/2.0.0
 [1.1.0]: https://github.com/forevermatt/budget-data/releases/tag/1.1.0
 [1.0.0]: https://github.com/forevermatt/budget-data/releases/tag/1.0.0

--- a/README.md
+++ b/README.md
@@ -15,26 +15,17 @@ The list of a user's financial accounts:
       *...*
     ]
 
-### Budget
-
-The amount a user has currently budgeted (per month) for each category:
-
-    {
-      "*category uuid*": {
-        "budgeted": *allotted amount for this month, in cents*,
-        "remaining": *amount remaining in this category*,
-        "refilled": "*YYYY-MM*"
-      },
-      *...*
-    }
-
 ### Categories
 
-A user's list of budget categories:
+A user's list of budget categories, including the amount currently budgeted (per
+month) for each category:
 
     [
       {
+        "budgeted": *allotted amount per month for this category, in cents*,
         "name": "*category name*",
+        "remaining": *amount remaining in this category*,
+        "refilled": "*YYYY-MM*"
         "uuid": "*category uuid*"
       },
       *...*

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ The IDs for each object (e.g. an Account ID) can be any non-empty identifier
 unique to that list of objects (e.g. Accounts). You can use UUIDs, but that is
 not required.
 
-You are also free to use `_id` rather than `id` as the name of the ID fields, AS
-LONG AS IT IS CLEAR which you are using (i.e. don't have both an `id` field and
-an `_id` field). However, foreign-key fields (such as `accountId`) must use the
-names documented below (i.e. do not use `account_id`).
+You are also free to use `_id` rather than `id` as the name of each of the ID
+fields, AS LONG AS IT IS CLEAR which you are using (i.e. don't have both an `id`
+field and an `_id` field). However, foreign-key fields (such as `accountId`)
+must use the names documented below (i.e. do not use `account_id`).
 
 ## Specification
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # Budget Data
 A data structure specification for budget apps
 
+## A Note about IDs
+
+The IDs for each object (e.g. an Account ID) can be any non-empty identifier
+unique to that list of objects (e.g. Accounts). You can use UUIDs, but that is
+not required.
+
+You are also free to use `_id` rather than `id` as the name of the ID fields, AS
+LONG AS IT IS CLEAR which you are using (i.e. don't have both an `id` field and
+an `_id` field). However, foreign-key fields (such as `accountId`) must use the
+names documented below (i.e. do not use `account_id`).
+
 ## Specification
 
 ### Accounts
@@ -10,7 +21,7 @@ The list of a user's financial accounts:
     [
       {
         "name": "*account name*",
-        "uuid": "*account uuid*"
+        "id": "*account id*"
       },
       *...*
     ]
@@ -26,7 +37,7 @@ month) for each category:
         "name": "*category name*",
         "remaining": *amount remaining in this category*,
         "refilled": "*YYYY-MM*"
-        "uuid": "*category uuid*"
+        "id": "*category id*"
       },
       *...*
     ]
@@ -35,11 +46,11 @@ month) for each category:
 
     [
       {
-        "uuid": "*transaction uuid*",
-        "accountUuid": "*account uuid*",
+        "id": "*transaction id*",
+        "accountId": "*account id*",
         "amountTotal": *transaction total, in cents*,
         "categoryAmounts": {
-          "*category uuid*": *amount from this category, in cents*,
+          "*category id*": *amount from this category, in cents*,
           *...*
         },
         "note": "*optional textual comment about this transaction*",


### PR DESCRIPTION
### Removed
- Remove `budget` data as a separate list

### Changed
- Merge `budget` data fields into `categories` data
- Rename `uuid` fields to `id` (or optionally `_id`)